### PR TITLE
Reminders screen switch styling fh

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize"
-      android:exported="true">
+      android:exported="true"
+      android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/data/tasks.jsx
+++ b/data/tasks.jsx
@@ -1,0 +1,20 @@
+const tasks = [
+    {
+     id: 1, key: "Tooth Brushing", discipline: "cleaning"
+    },
+    {
+        id: 2, key: "Rubber bands", discipline: "maintenance"
+    },
+    {
+       id: 3, key: "Clear Aligners", discipline: "maintenance"
+    },
+    {
+       id:4,  key: "Retainers", discipline: "cleaning"
+    },
+    {
+        id:5,  key: "Oral Habits", discipline: "cleaning"
+    },
+]
+
+export default tasks;
+        

--- a/screens/Reminders.jsx
+++ b/screens/Reminders.jsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
-import { View, Text, TouchableOpacity, Button, StyleSheet } from "react-native";
+import { View, Text, TouchableOpacity, Button, StyleSheet, Switch } from "react-native";
 import ToothBrushing from "./ToothBrushing";
 import { useNavigation } from "@react-navigation/native";
 import scheduleLocalNotification from "../services/RemindersService";
+import logo from "../assets/logo.png";
+
+const LOGO = logo;
 
 function RemindersScreen() {
     const navigation = useNavigation();

--- a/screens/Reminders.jsx
+++ b/screens/Reminders.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { View, Text, TouchableOpacity, Button, StyleSheet, Switch } from "react-native";
+import { View, Text, TouchableOpacity, Button, StyleSheet, Switch, Image } from "react-native";
 import ToothBrushing from "./ToothBrushing";
 import { useNavigation } from "@react-navigation/native";
 import scheduleLocalNotification from "../services/RemindersService";
 import logo from "../assets/logo.png";
+import tasks from "../data/tasks";
 
 const LOGO = logo;
 

--- a/screens/Reminders.jsx
+++ b/screens/Reminders.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { View, Text, TouchableOpacity, Button, StyleSheet, Switch, Image } from "react-native";
+import { View, Text, TouchableOpacity, Button, StyleSheet, Switch, Image, FlatList } from "react-native";
 import ToothBrushing from "./ToothBrushing";
 import { useNavigation } from "@react-navigation/native";
 import scheduleLocalNotification from "../services/RemindersService";
@@ -10,24 +10,52 @@ const LOGO = logo;
 
 function RemindersScreen() {
     const navigation = useNavigation();
-  
+    
+    const [taskSwitches, setTaskSwitches] = useState({});
+
+    const handleSwitch = (taskId, value) => {
+        setTaskSwitches(prevSwitches => ({
+          ...prevSwitches,
+          [taskId]: value // Using the task ID as the key to store each task's switch state
+        }));
+    };
+
     const handlePress = () => {
       navigation.navigate('ToothBrushing'); // Navigate to ToothBrushing screen
     };
       
     return (
         <View style={styles.container}>
-            {/* Other content */}
-            <Button style= {styles.item} title="Tooth Brushing" onPress={handlePress} />
-        </View>
+        <Image source={LOGO} style={styles.logo} />
+      <FlatList
+        data={tasks}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => handlePress(item)} style={styles.listItem}>
+            <Text style={styles.item}>{item.key}</Text>
+            <Switch
+              style={{ transform: [{ scaleX: 1.5 }, { scaleY: 1.5 }] }}
+              trackColor={{ false: "#ffa500", true: "#50C878" }}
+              thumbColor={taskSwitches[item.id] ? "#ffffff" : "#fffffff"}
+              ios_backgroundColor="#3e3e3e"
+              onValueChange={(value) => handleSwitch(item.id, value)}
+              value={taskSwitches[item.id] || false}  // This line makes sure each switch has its own unique state
+            />
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+
     );
 }
 const styles = StyleSheet.create({
     container: {
-        flex: 1,
-        padding: 20,
+        flex: 0,
+        //padding: 20,
         backgroundColor: '#ffffff',
-        justifyContent: "center", // Center the content vertically
+        height: "100%",
+        flexDirection: "column",
+        backgroundColor: '#ffffff',
+        justifyContent: "space-around", // Center the content vertically
         alignItems: "center", // Center the content horizontally
         
     },
@@ -35,7 +63,7 @@ const styles = StyleSheet.create({
         width: 100, // Set a width for the logo
         height: 100, // Set a height for the logo (you can adjust as needed)
         resizeMode: "contain", // Keep the logo's aspect ratio
-        marginBottom: 20
+        marginBottom: 80
     },
     item: {
         padding: 10,
@@ -51,5 +79,13 @@ const styles = StyleSheet.create({
         textAlign: 'center',
     
     },
+
+    listItem: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-around', // This already makes sure there's space between items
+        padding: 5,
+        width: '100%', // Use full width of the container
+      },
 }); 
 export default RemindersScreen;


### PR DESCRIPTION
# Synopsis

The purpose of this pull request is to merge style features made in the ` reminders-screen-switch-functionality-and-styling-fh ` branch to the ` test branch `.

The concept of this branch was to incorporate the styling that was made in our other codebase to the codebase in this repository.
The styling was requested by the clients and had to match their preferences.

 ### The Client's Design Concept:

![image](https://github.com/farhayden/BraceMinder/assets/83618008/d18d6fea-1d1b-438f-bff6-8817de0e3049)

### What we Implemented:

![image](https://github.com/farhayden/BraceMinder/assets/83618008/0eb26b14-f0cb-4ac4-9f89-2213b87c534c)

## Conclusion

This branch was only to add the style features. The functionality and navigation to the correct screens using the menu system will be implemented in ` sprint-7 `.